### PR TITLE
Update Sass to work with Middleman 3.3.6

### DIFF
--- a/middleman-automatic-clowncar.gemspec
+++ b/middleman-automatic-clowncar.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
 
   # These are here to make sure that we don't have any collisions with sprockets
   spec.add_dependency "middleman-sprockets", "> 3.2.0"
-  spec.add_dependency "sass", ">= 3.2.14"
+  spec.add_dependency "sass", "~> 3.4.0"
 
-  spec.add_development_dependency "bundler", ">= 1.5"
+  spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "cucumber", "~> 1.3.10"
   spec.add_development_dependency "aruba",    "~> 0.5.1"

--- a/middleman-automatic-clowncar.gemspec
+++ b/middleman-automatic-clowncar.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
 
   # These are here to make sure that we don't have any collisions with sprockets
   spec.add_dependency "middleman-sprockets", "> 3.2.0"
-  spec.add_dependency "sass", "~> 3.2.14"
+  spec.add_dependency "sass", ">= 3.2.14"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "cucumber", "~> 1.3.10"
   spec.add_development_dependency "aruba",    "~> 0.5.1"


### PR DESCRIPTION
Error when running bundle exec:

middleman-automatic-clowncar (~> 0.0.2) ruby depends on
      sass (~> 3.2.14) ruby

    middleman (~> 3.3.6) ruby depends on
      sass (3.4.5)

