### PR TITLE
Fix for Ruby 3.2 which drops the File.exists? alias of File.exist?

### DIFF
--- a/lib/middleman-automatic-clowncar/sitemap-extension.rb
+++ b/lib/middleman-automatic-clowncar/sitemap-extension.rb
@@ -26,7 +26,7 @@ module Middleman
               resources = resources - default_resource
             end
             dest_path = File.join(@app.root_path,'build', spec[:name])
-            source = File.exists?(dest_path) ? dest_path : file
+            source = File.exist?(dest_path) ? dest_path : file
             resource_list << Middleman::AutomaticClowncar::ThumbnailResource.new(@app.sitemap,spec[:name],spec[:dimensions],file,@app.root_path,'build',@app.source_dir)
             #resource_list << Middleman::Sitemap::Resource.new(@app.sitemap, spec[:name], source) unless name == :original
           end


### PR DESCRIPTION
per:
https://stackoverflow.com/questions/14351272/undefined-method-exists-for-fileclass-nomethoderror

3.2 drops the alias